### PR TITLE
Add compatibility for Python 3

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # ansible_cmd
 #
@@ -50,7 +50,7 @@ class Ansible(object):
                 x = json.loads(''.join(s))
                 self.update_host(hostname, x)
                 self.update_host(hostname, {'name': hostname})
-            except ValueError, e:
+            except ValueError as e:
                 # Ignore non-JSON files (and bonus errors)
                 sys.stderr.write("Error parsing: %s: %s\n" % (fname, e))
 

--- a/src/html_fancy.tpl
+++ b/src/html_fancy.tpl
@@ -59,10 +59,10 @@ cols = [
   ${host['ansible_facts'].get('ansible_virtualization_type', '')} / ${host['ansible_facts'].get('ansible_virtualization_role', '')}
 </%def>
 <%def name="col_disk_total(host)">
-  ${', '.join([str(i['size_total']/1048576000) + 'g' for i in host['ansible_facts'].get('ansible_mounts', []) if i['size_total']/1048576000 > 1])}
+  ${', '.join([str(round(i['size_total']/1048576000.0, 2)) + 'g' for i in host['ansible_facts'].get('ansible_mounts', []) if i['size_total']/1048576000.0 > 1])}
 </%def>
 <%def name="col_disk_avail(host)">
-  ${', '.join([str(i['size_available']/1048576000) + 'g' for i in host['ansible_facts'].get('ansible_mounts', []) if i['size_available']/1048576000 > 1])}
+  ${', '.join([str(round(i['size_available']/1048576000.0,2)) + 'g' for i in host['ansible_facts'].get('ansible_mounts', []) if i['size_available']/1048576000.0 > 1])}
 </%def>
 <%def name="col_disk_usage(host)">
   % for i in host['ansible_facts'].get('ansible_mounts', []):


### PR DESCRIPTION
With this changes the script can be run with Python 3 also. Because of the change
```
except ValueError, e
```
to
```
except ValueError as e
```
the minimum version for Python 2 is 2.6

I also changed the shebang to ``#!/usr/bin/env python`` so you can use ansible-cmdb in an venv.