### PR TITLE
Remove an errant print statement.

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -76,8 +76,6 @@ class Ansible(object):
         else:
             hosts_contents = file(hosts_file, 'r').readlines()
 
-        print hosts_contents
-
         # Go through the file line by line and map every line to the group they
         # belong to. There are three groups: normal, vars and children.
         for line in hosts_contents:


### PR DESCRIPTION
It appears as through a print statement was used for debugging, but not
removed before the commit. This had the side effect of printing the
inventory file into the top of the output file.