### PR TITLE
Install manual page as "ansible-cmdb.1"

### DIFF
--- a/contrib/release_Makefile
+++ b/contrib/release_Makefile
@@ -7,7 +7,7 @@ fake:
 install:
 	mkdir -p /usr/local/lib/${PROG}
 	cp -a * /usr/local/lib/${PROG}/
-	cp -a ansible-cmdb.man.1 /usr/local/share/man/man1/
+	cp -a ansible-cmdb.man.1 /usr/local/share/man/man1/ansible-cmdb.1
 	ln -s /usr/local/lib/${PROG}/ansible-cmdb /usr/local/bin/ansible-cmdb
 	mandb -p -q
 


### PR DESCRIPTION
Don't install the manual page as `ansible-cmdb.man.1` but as `ansible-cmdb.1 `.