### PR TITLE
Run "mandb" only if it is available

### DIFF
--- a/contrib/release_Makefile
+++ b/contrib/release_Makefile
@@ -9,7 +9,7 @@ install:
 	cp -a * /usr/local/lib/${PROG}/
 	cp -a ansible-cmdb.man.1 /usr/local/share/man/man1/
 	ln -s /usr/local/lib/${PROG}/ansible-cmdb /usr/local/bin/ansible-cmdb
-	mandb -p -q
+	if command -v mandb >/dev/null; then mandb -p -q; fi
 
 uninstall:
 	rm -rf /usr/local/lib/${PROG}


### PR DESCRIPTION
For example OS X does not ship a "mandb" command, therefore "make install"
fails on this platform without this patch.