### PR TITLE
Fix surrounding whitespace in ansible.cfg options

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         with open(config_file, 'r') as cf:
             for line in cf:
                 if line.startswith('hostfile'):
-                    options.inventory = line.strip().split('=', 1)[1]
+                    options.inventory = line.split('=', 1)[1].strip()
     log.debug('inventory hostfile = {0}'.format(options.inventory))
 
     # Handle template params


### PR DESCRIPTION
ansible-cmdb will fail if the `hostfile` option is
surrounded by whitespaces like `hostfile = inventory`.

Thus it will produce output like `' inventory'`.

This patch simply strips whitespaces and newlines
in the end of parsing the `hostfile` line.