### PR TITLE
Fixing typo that breaks name urls on html_fancy

### DIFF
--- a/src/ansiblecmdb/data/tpl/html_fancy.tpl
+++ b/src/ansiblecmdb/data/tpl/html_fancy.tpl
@@ -41,7 +41,7 @@ if columns is not None:
 ## Column functions
 ##
 <%def name="col_name(host)">
-  <a href="#${jsonxs(host, 'name')}["name"]}">${jsonxs(host, "name")}</a>
+  <a href="#${jsonxs(host, 'name')}">${jsonxs(host, "name")}</a>
 </%def>
 <%def name="col_dtap(host)">
   ${jsonxs(host, 'hostvars.dtap', default='')}


### PR DESCRIPTION
Line 43 on https://github.com/fboender/ansible-cmdb/commit/0401cfda02f7138bd6ed3362e904d705b0e99a2b has a typo that breaks name URLs on the html_fancy page. URLs in the generated HTML look like the following:
```
  <a href="#hostname["name"]}">hostname</a>
</td>
```
The bad href value that is generated is **#hostname[**, the part between the first two quotes. This patch simply removes the legacy _["name"]}_ code so that these links work as normal.