### PR TITLE
Fix for HP-UX missing netmask from ansible facts

### DIFF
--- a/src/ansiblecmdb/data/tpl/html_fancy.tpl
+++ b/src/ansiblecmdb/data/tpl/html_fancy.tpl
@@ -318,7 +318,11 @@ if columns is not None:
                     <td>${iface_name}</td>
                     <td>${net['address']}</td>
                     <td>${net['network']}</td>
-                    <td>${net['netmask']}</td>
+                    % if 'netmask' in net:
+                      <td>${net['netmask']}</td>
+                    % else:
+                      <td></td>
+                    % endif
                   </tr>
                 % endif
               % endfor


### PR DESCRIPTION
Seems there is a bug in ansible fact gathering on HP-UX.  All of our servers network devices aren't gathering netmask facts. This is a simple fix to check if a netmask exist prior to printing a null variable and causing the following error:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-cmdb", line 122, in <module>
    out = mytemplate.render(hosts=ansible.hosts, **params)
  File "/usr/local/lib/ansible-cmdb/mako/template.py", line 443, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/local/lib/ansible-cmdb/mako/runtime.py", line 803, in _render
    **_kwargs_for_callable(callable_, data))
  File "/usr/local/lib/ansible-cmdb/mako/runtime.py", line 835, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/local/lib/ansible-cmdb/mako/runtime.py", line 860, in _exec_template
    callable_(context, *args, **kwargs)
  File "/usr/local/lib/ansible-cmdb/ansiblecmdb/data/tpl/html_fancy.tpl", line 586, in render_body
    <% host_network(host) %>
  File "/usr/local/lib/ansible-cmdb/ansiblecmdb/data/tpl/html_fancy.tpl", line 0, in host_network
    
  File "/usr/local/lib/ansible-cmdb/ansiblecmdb/data/tpl/html_fancy.tpl", line 321, in render_host_network
    <td>${net['netmask']}</td>
KeyError: 'netmask'

Whoops, it looks like something went wrong while rendering the template.

The reported error was: 'netmask'