### PR TITLE
Fix dynamic inventories with INI files

### DIFF
--- a/src/ansiblecmdb/ansible.py
+++ b/src/ansiblecmdb/ansible.py
@@ -59,6 +59,10 @@ class Ansible(object):
         elif os.path.isdir(inventory_path):
             # Scan directory
             for fname in os.listdir(inventory_path):
+                # Skip files that end with certain extensions or characters
+                if any(fname.endswith(ext) for ext in ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"]):
+                    continue
+
                 self._handle_inventory(os.path.join(inventory_path, fname))
         else:
             sys.stderr.write("Not a file or directory: '{}'\n".format(inventory_path))

--- a/test/f_inventory/mixeddir/config.ini
+++ b/test/f_inventory/mixeddir/config.ini
@@ -1,0 +1,4 @@
+# Just empty ini file
+[empty]
+
+ini_setting = 1

--- a/test/test.py
+++ b/test/test.py
@@ -112,6 +112,8 @@ class InventoryTestCase(unittest.TestCase):
         self.assertIn("moocow.example.com", ansible.hosts)
         # results from normal hosts file.
         self.assertIn("web03.dev.local", ansible.hosts)
+        # INI file ignored.
+        self.assertNotIn("ini_setting", ansible.hosts)
 
 
 class FactCacheTestCase(unittest.TestCase):


### PR DESCRIPTION
Many dynamic inventory scripts use INI files for configuration and currently they are treated as regular hosts files.

Ansible [skip certain extensions](https://docs.ansible.com/ansible/intro_dynamic_inventory.html#using-inventory-directories-and-multiple-inventory-sources) when reading inventory directory.