### PR TITLE
Added inventory parameter to the ansible command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Usage
 First, generate Ansible output for your hosts:
 
     mkdir out
-    ansible -m setup --tree out/ all
+    ansible -i hosts -m setup --tree out/ all
 
 Next, call ansible-cmdb on the resulting `out/` directory to generate the CMDB
 overview page:


### PR DESCRIPTION
The most user doesn't use the standard inventory file (/etc/ansible/hosts) and they need to specify their own inventory file in the ansible command to get the correct setup information of the servers. 