### PR TITLE
Allow folders in group_vars

### DIFF
--- a/src/ansiblecmdb/ansible.py
+++ b/src/ansiblecmdb/ansible.py
@@ -160,7 +160,7 @@ class Ansible(object):
 
         for (dirpath, dirnames, filenames) in os.walk(path):
             for filename in filenames:
-                f_path = os.path.join(path, filename)
+                f_path = os.path.join(dirpath, filename)
                 groupname = filename
 
                 # Check for ansible-vault files, because they're valid yaml for


### PR DESCRIPTION
In our group_vars directory, we use something like that:
```
group_vars/
  all/
    users.yml
    repositories.yml
    global.yml
  cassandra.yml
  kafka.yml
  ... 
        
```
The current ansible-cmdb would failed with:
```
IOError: [Errno 2] No such file or directory: 'inventories/aws/group_vars/global.yml'
```

I've made this little change to make ansible-cmdb to be able to access any `group_vars` subdirectory content.