### PR TITLE
Update parser.py to handle comment line variations.

### DIFF
--- a/src/ansiblecmdb/parser.py
+++ b/src/ansiblecmdb/parser.py
@@ -206,7 +206,7 @@ class HostsParser(object):
         """
         key_values = {}
         for token in tokens:
-            if token == '#':
+            if token.startswith('#'):
                 # End parsing if we encounter a comment, which lasts
                 # until the end of the line.
                 break


### PR DESCRIPTION
Enable comment tokens to start with a '#'.  Thus "#A comment" and "# A comment" are both acceptable.