### PR TITLE
Include for showing the packages facts 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,10 +18,27 @@ information for each host.
 
 You can now open `overview.html` in your browser to view the results.
 
+## Packages_facts html generation
+
+First, generate Ansible output for your hosts:
+
+    mkdir out
+    ansible -m setup --tree out/outsetup all
+    ansible -m package_facts --tree out/outpackages all
+
+Next, call ansible-cmdb on the resulting `out/` directory to generate the CMDB
+overview page:
+
+    ansible-cmdb out/outsetup out/outpackages > overview.html
+
+You can now open `overview.html` in your browser to view the results, with the packages.
+We use the [package_facts module](https://docs.ansible.com/ansible/2.5/modules/package_facts_module.html) and the [setup module](https://docs.ansible.com/ansible/2.5/modules/setup_module.html)
+
+
 ## Full usage
 
     Usage: ansible-cmdb [option] <dir> > output.html
-    
+
     Options:
       --version             show program's version number and exit
       -h, --help            show this help message and exit
@@ -89,16 +106,16 @@ For example, let's say we have the following `hosts` file:
     [cust.megacorp]
     db1.dev.megacorp.com   dtap=dev  comment="Old database server"
     db2.dev.megacorp.com   dtap=dev  comment="New database server"
-    test.megacorp.com      dtap=test 
+    test.megacorp.com      dtap=test
     acc.megacorp.com       dtap=acc  comment="24/7 support"
     megacorp.com           dtap=prod comment="Hosting by Foo" ext_id="SRV_10029"
-    
+
     [os.redhat]
     megacorp.com
     acc.megacorp.com
     test.megacorp.com
     db2.dev.megacorp.com
-    
+
     [os.debian]
     db1.dev.megacorp.com
 
@@ -181,7 +198,7 @@ hosts and the html_fancy template is rendering too slow.
 
 Usage:
 
-    ansible-cmdb -t html_fancy_split -i hosts out/ 
+    ansible-cmdb -t html_fancy_split -i hosts out/
 
 It accepts the same parameters as the `html_fancy` template.
 
@@ -191,7 +208,7 @@ The `sql` template generates an .sql file that can be loaded into an SQLite or
 MySQL database.
 
     $ ansible-cmdb -t sql -i hosts out > cmdb.sql
-    $ echo "CREATE DATABASE ansiblecmdb" | mysql 
+    $ echo "CREATE DATABASE ansiblecmdb" | mysql
     $ mysql ansiblecmdb < cmdb.sql
 
 ## Fact caching
@@ -218,7 +235,7 @@ the root of the JSON.
 
 Some templates, such as txt_table and html_fancy,  support columns. If a
 template supports columns, you can use the `--columns` / `-c` command line
-option to specify which columns to show. 
+option to specify which columns to show.
 
 The `--columns` takes a comma-separated list of columns (no spaces!) which
 should be shown.  The columns must be specified by their `id` field. For
@@ -241,7 +258,7 @@ For example:
     win.dev.local           Windows 2012   10.0.0.3       4g   0  
     host5.example.com       Debian 6.0.10  192.168.57.1   1g   1  
     db03.prod.local         Debian 6.0.10  192.168.58.3   0g   1  
-    zoltar.electricmonk.nl  Ubuntu 14.04   194.187.79.11  4g   2 
+    zoltar.electricmonk.nl  Ubuntu 14.04   194.187.79.11  4g   2
 
 For interactive templates (`html_fancy` and friends), the `--columns` option
 merely hides the columns by default. It doesn't remove them from the output,
@@ -263,7 +280,7 @@ hosts.
 
 Extended facts are basically the same as normal Ansible fact files. When you
 specify multiple fact directories, Ansible-cmdb scans all of the in order and
-overlays the facts. 
+overlays the facts.
 
 Note that the host *must still* be present in your hosts file, or it will not
 generate anything.
@@ -321,29 +338,29 @@ Create a file in it for your windows host:
         "ansible_all_ipv4_addresses": [
           "10.10.0.2",
           "191.37.104.122"
-        ], 
+        ],
         "ansible_default_ipv4": {
           "address": "191.37.104.122"
-        }, 
+        },
         "ansible_devices": {
-        }, 
-        "ansible_distribution": "Windows", 
-        "ansible_distribution_major_version": "2008", 
-        "ansible_distribution_release": "", 
-        "ansible_distribution_version": "2008", 
-        "ansible_domain": "win.dev.local", 
-        "ansible_fips": false, 
-        "ansible_form_factor": "VPS", 
-        "ansible_fqdn": "win.dev.local", 
-        "ansible_hostname": "win", 
-        "ansible_machine": "x86_64", 
-        "ansible_nodename": "win.dev.local", 
-        "ansible_userspace_architecture": "x86_64", 
-        "ansible_userspace_bits": "64", 
-        "ansible_virtualization_role": "guest", 
-        "ansible_virtualization_type": "xen", 
+        },
+        "ansible_distribution": "Windows",
+        "ansible_distribution_major_version": "2008",
+        "ansible_distribution_release": "",
+        "ansible_distribution_version": "2008",
+        "ansible_domain": "win.dev.local",
+        "ansible_fips": false,
+        "ansible_form_factor": "VPS",
+        "ansible_fqdn": "win.dev.local",
+        "ansible_hostname": "win",
+        "ansible_machine": "x86_64",
+        "ansible_nodename": "win.dev.local",
+        "ansible_userspace_architecture": "x86_64",
+        "ansible_userspace_bits": "64",
+        "ansible_virtualization_role": "guest",
+        "ansible_virtualization_type": "xen",
         "module_setup": true
-      }, 
+      },
       "changed": false
     }
 
@@ -401,4 +418,3 @@ Generate the overview:
     ./ansible-cmdb out/ out_custom/ > overview.html
 
 The software items will be listed under the "*Custom facts*" heading.
-

--- a/src/ansiblecmdb/data/tpl/html_fancy_defs.html
+++ b/src/ansiblecmdb/data/tpl/html_fancy_defs.html
@@ -25,6 +25,8 @@
     {"title": "All IPv6",      "id": "all_ipv6",      "func": col_all_ip6,        "sType": "string", "visible": False},
     {"title": "OS",            "id": "os",            "func": col_os,             "sType": "string", "visible": True},
     {"title": "Kernel",        "id": "kernel",        "func": col_kernel,         "sType": "string", "visible": False},
+    {"title": "Curl 64 bits",  "id": "curl64",        "func": col_curl64,         "sType": "string", "visible": False},
+    {"title": "Curl 32 bits",  "id": "curl32",        "func": col_curl32,         "sType": "string", "visible": False},
     {"title": "Arch",          "id": "arch",          "func": col_arch,           "sType": "string", "visible": False},
     {"title": "Virt",          "id": "virt",          "func": col_virt,           "sType": "string", "visible": True},
     {"title": "CPU type",      "id": "cpu_type",      "func": col_cpu_type,       "sType": "string", "visible": False},
@@ -47,7 +49,7 @@
         col["visible"] = True
       else:
         col["visible"] = False
-  
+
   # Remove columns that should be excluded
   if cols_exclude is not None:
     cols = filter(lambda col: col["id"] not in cols_exclude, cols)
@@ -130,14 +132,14 @@
       dl, dt, dd, ol, ul, li,
       fieldset, form, label, legend,
       table, caption, tbody, tfoot, thead, tr, th, td,
-      article, aside, canvas, details, embed, 
-      figure, figcaption, footer, header, hgroup, 
+      article, aside, canvas, details, embed,
+      figure, figcaption, footer, header, hgroup,
       menu, nav, output, ruby, section, summary,
-      time, mark, audio, video { 
+      time, mark, audio, video {
         margin: 0; padding: 0; border: 0; font-size: 100%; font: inherit; vertical-align: baseline;
       }
       /* HTML5 display-role reset for older browsers */
-      article, aside, details, figcaption, figure, 
+      article, aside, details, figcaption, figure,
       footer, header, hgroup, menu, nav, section { display: block; }
       body { line-height: 1; }
       ol, ul { list-style: none; }
@@ -145,13 +147,13 @@
       blockquote:before, blockquote:after,
       q:before, q:after { content: ''; content: none; }
       table { border-collapse: collapse; border-spacing: 0; }
-  
+
       /* ansible-cmdb */
       *, body { font-family: sans-serif; font-weight: lighter; }
       a { text-decoration: none; }
       b { font-weight: bold; }
       p { margin-bottom: 1em; }
-  
+
       header { position: fixed; top: 0px; left: 0px; right: 0px; background-color: #0071b8; overflow: auto; color: #E0E0E0; padding: 15px; z-index: 1000; }
       header h1 { font-size: x-large; float: left; line-height: 32px; font-weight: bold; }
       header #clear_settings { float: right; line-height: 32px; font-size: small; margin-left: 12px; }
@@ -160,17 +162,17 @@
       header #top { display: none; }
       header #top a { line-height: 32px; margin-left: 64px; color: #FFFFFF; border-bottom: 1px solid #909090; }
       header #generated .detail { font-weight: bold; }
-  
+
       footer { display: block; position: fixed; bottom: 0px; right: 0px; left: 0px; background-color: #d5d5d5; overflow: auto; color: #505050; padding: 4px; font-size: x-small; text-align: right; padding-right: 8px; }
       footer a { font-weight: bold; text-decoration: none; color: #202020; }
-  
+
       #col_toggles { margin: 32px; margin-top: 100px; }
       #col_toggles h2 { display: block; font-size: 1.4em; margin-bottom: 32px; color: #606060; }
       #col_toggle_buttons { margin-left: 32px; font-weight: normal; line-height: 40px; }
       #col_toggles a { line-height: 40px; }
       #col_toggles a { display: inline-block; background-color: #009688; line-height: 32px; padding: 0px 15px 0px 15px; margin-right: 6px; box-shadow: 2px 2px 0px 0px rgba(0,0,0,0.35); color: #FFFFFF; }
       #col_toggles a.col-invisible { background-color: #B0B0B0; box-shadow: 0 0px 0px 0; }
-  
+
       #host_overview { margin: 32px; }
       #host_overview h2 { display: block; font-size: 1.4em; color: #606060; }
       #host_overview_tbl_wrapper{ margin-left: 16px; }
@@ -191,7 +193,7 @@
       #host_overview .prog_bar_used { display: block; height: 12px; background-color: #8F4040; }
       #host_overview tbody td.error a { color: #FF0000; }
       #host_overview span.usage_detail { color: #606060; }
-  
+
       #hosts { margin-left: 32px; margin-bottom: 120px; }
       #hosts .toggle-collapse { cursor: pointer; }
       #hosts a.toggle-all { margin-top: 20px; display: inline-block; color: #0080FF; }
@@ -227,7 +229,7 @@
   <header>
     <h1>${title}</h1>
     <span id="top"><a href="#">Back to top</a></span>
-    <span id="clear_settings"><a href="javascript:window.localStorage.clear('columnVisibility'); location.reload();" title="If things are acting weird, press this button">Clear settings</a></span> 
+    <span id="clear_settings"><a href="javascript:window.localStorage.clear('columnVisibility'); location.reload();" title="If things are acting weird, press this button">Clear settings</a></span>
     <span id="generated">Generated on <span class="detail">${datetime.datetime.now().strftime('%c')}</span> by <span class="detail">${getpass.getuser()}</span> @ <span class="detail">${socket.getfqdn()}</span></span>
   </header>
 </%def>
@@ -371,7 +373,7 @@
         {
           "targets": [${loop.index}],
           "visible": ${str(col['visible']).lower()},
-          "sType": "${col['sType']}" 
+          "sType": "${col['sType']}"
         },
       % endfor
     ],
@@ -420,7 +422,7 @@
     columnVisibility[columnId] = column.visible();
     localStorage.setItem("columnVisibility", JSON.stringify(columnVisibility));
   });
-  
+
   // Open the Detailed host information when jumping to a host.
   $('#host_overview td a').on('click', function(e) {
     var hostId=$(this).attr('href').substr(1);
@@ -438,7 +440,7 @@
     $(this).toggleClass('uncollapsed');
     $(this).next().toggleClass('collapsed');
   });
-  
+
   // Toggle opening and closing all information for a host.
   $('a.toggle-all').on('click', function(e) {
     e.preventDefault();
@@ -535,6 +537,14 @@
   ${jsonxs(host, 'ansible_facts.ansible_kernel', default='')}
 </%def>
 
+<%def name="col_curl64(host, **kwargs)">
+  ${jsonxs(host, 'ansible_facts.packages.libcurl[0].version', default='')}
+</%def>
+
+<%def name="col_curl32(host, **kwargs)">
+${jsonxs(host, 'ansible_facts.packages.libcurl.[1].version', default='')}
+</%def>
+
 <%def name="col_arch(host, **kwargs)">
   ${jsonxs(host, 'ansible_facts.ansible_architecture', default='')} / ${jsonxs(host, 'ansible_facts.ansible_userspace_architecture', default='')}
 </%def>
@@ -565,7 +575,7 @@
 <%def name="col_mem_usage(host, **kwargs)">
   % try:
     <%
-    i = jsonxs(host, 'ansible_facts.ansible_memory_mb', default=0) 
+    i = jsonxs(host, 'ansible_facts.ansible_memory_mb', default=0)
     sort_used = '%f' % (float(jsonxs(i, "nocache.used", default=0)) / jsonxs(i, "real.total", default=0))
     used = float(i["nocache"]["used"]) / i["real"]["total"] * 100
     detail_used = round(jsonxs(i, "nocache.used", default=0) / 1024.0, 1)
@@ -643,7 +653,7 @@
       ${physdisk_name}: ${jsonxs(physdisk_info, 'size', default='')}<br />
     % endfor
   % except AttributeError:
-    
+
   % endtry
 </%def>
 


### PR DESCRIPTION
Ansible 2.5.0 is out and the packages facts is supported so i propose to at least explain 
https://docs.ansible.com/ansible/2.5/modules/package_facts_module.html

or integrate into the existing templeting or to add a new template only for demonstrate how to recover packages_facts

I use in my exemple of curl but it can be another package that is usefull.


For generate ansible output for your hosts 

```
ansible -m setup --tree out/outsetup all 
ansible -m package_facts --tree out/outpackages all
Then generate the html 
ansible-cmdb out/outsetup out/outpackages > overview.html
```

Into the html template by exemple you can do: 
```

{"title": "Curl 64 bits",   "id": "curl64",        "func": col_curl64,          "sType": "string", "visible": True},
{"title": "Curl 32 bits",  "id": "curl32",         "func": col_curl32,          "sType": "string", "visible": True},
```
And add with libcurl the name of the package 
```
<%def name="col_curl64(host, **kwargs)">
  ${jsonxs(host, 'ansible_facts.packages.libcurl[0].version', default='')}
</%def>

<%def name="col_curl32(host, **kwargs)">
${jsonxs(host, 'ansible_facts.packages.libcurl.[1].version', default='')}
</%def>
```