### PR TITLE
Ini parse fixes

### DIFF
--- a/src/ansiblecmdb/parser.py
+++ b/src/ansiblecmdb/parser.py
@@ -203,14 +203,8 @@ class HostsParser(object):
         """
         key_values = {}
         for token in tokens:
-            if token.startswith('#'):
-                # End parsing if we encounter a comment, which lasts
-                # until the end of the line.
-                break
-            else:
-                k, v = token.split('=', 1)
-                key = k.strip()
-                key_values[key] = v.strip()
+            k, v = token.split('=', 1)
+            key_values[k.strip()] = v.strip()
         return key_values
 
     def _get_distinct_hostnames(self):

--- a/src/ansiblecmdb/parser.py
+++ b/src/ansiblecmdb/parser.py
@@ -143,53 +143,53 @@ class HostsParser(object):
         Returns:
             (None, {'purpose': 'web'})
 
-        Undocumented feature:
+        In :vars sections everything to the right of key=value is a string.
+        Comments are removed and leading and trailing spaces are stripped.
             [prod:vars]
-            json_like_vars=[{'name': 'htpasswd_auth'}]
+            json_like_vars = [{'name': 'htpasswd_auth'}]
         Returns:
-            (None, {'name': 'htpasswd_auth'})
+            (None, "[{'name': 'htpasswd_auth'}]")
         """
-
-        name = None
-        key_values = {}
+        line = self.remove_comment_from_line(line)
 
         if type == 'vars':
-            key_values = self._parse_line_vars(line)
-        else:
-            tokens = shlex.split(line.strip())
-            name = tokens.pop(0)
-            try:
-                key_values = self._parse_vars(tokens)
-            except ValueError:
-                self.log.warning("Unsupported vars syntax. Skipping line: {0}".format(line))
-                return (name, {})
-        return (name, key_values)
+            k, v = line.split('=', 1)
+            return None, {k.strip(): v.strip()}
 
-    def _parse_line_vars(self, line):
+        tokens = shlex.split(line)
+        name = tokens.pop(0)
+        try:
+            key_values = self._parse_vars(tokens)
+        except ValueError:
+            self.log.warning("Unsupported vars syntax. Skipping line: {0}", line)
+            return name, {}
+
+        return name, key_values
+
+    # Lightly adapted from https://stackoverflow.com/questions/2319019/using-regex-to-remove-comments-from-source-files
+    def remove_comment_from_line(self, line):
         """
-        Parse a line in a [XXXXX:vars] section.
+        Return the string obtained by removing any # comment from the line,
+        respecting quoted strings.
         """
-        key_values = {}
+        # I don't think this is actually completely correct as quoted
+        # backslashes will probably cause trouble -- consider what
+        # might happen with multiple \', \" and \\ in a line, but it
+        # might be close enough for government work.
+        pattern = r'''(".*?"|'.*?')|(#.*)'''
+        # first group captures quoted strings (double or single)
+        # second group captures comments
+        regex = re.compile(pattern)
 
-        # Undocumented feature allows json in vars sections like so:
-        #   [prod:vars]
-        #   json_like_vars=[{'name': 'htpasswd_auth'}]
-        # We'll try this first. If it fails, we'll fall back to normal var
-        # lines. Since it's undocumented, we just assume some things.
-        k, v = line.strip().split('=', 1)
-        if v.startswith('['):
-            try:
-                list_res = ihateyaml.safe_load(v)
-                if isinstance(list_res[0], dict):
-                    key_values = list_res[0]
-                    return key_values
-            except ValueError:
-                pass
+        def _replacer(match):
+            # if we captured a comment in group 2, remove it
+            # otherwise return the captured quoted string in group 1
+            if match.group(2) is not None:
+                return ''
+            else:
+                return match.group(1)
 
-        # Guess it's not YAML. Parse as normal host variables
-        tokens = shlex.split(line.strip())
-        key_values = self._parse_vars(tokens)
-        return key_values
+        return regex.sub(_replacer, line)
 
     def _parse_vars(self, tokens):
         """

--- a/test/f_hostparse/hosts_ini_key_value
+++ b/test/f_hostparse/hosts_ini_key_value
@@ -1,0 +1,36 @@
+# -*-conf-*-
+
+# INI format key=value documentation from docs.ansible.com
+#
+# <quote>
+# Values passed in the INI format using the key=value syntax are
+# interpreted differently depending on where they are declared:
+#
+# When declared inline with the host, INI values are interpreted as
+# Python literal structures (strings, numbers, tuples, lists, dicts,
+# booleans, None). Host lines accept multiple key=value parameters per
+# line. Therefore they need a way to indicate that a space is part of
+# a value rather than a separator.
+#
+# When declared in a :vars section, INI values are interpreted as
+# strings. For example var=FALSE would create a string equal to
+# ‘FALSE’. Unlike host lines, :vars sections accept only a single
+# entry per line, so everything after the = must be the value for the
+# entry.</quote>
+
+[db]
+db.dev.local
+
+[db:vars]
+# This is a string valued variable that Ansible will automagically
+# convert to a list when used in some contexts.  It is *not* YAML and
+# the items must be quoted as it is interpreted as a Python literal.
+# The comment should be ignored.
+simple_list = ["item1", "item2"]  # list string
+
+# This is a string valued var that Ansible will automagically convert
+# to a dictionary when used in some contexts.  It is *not* YAML so the
+# items must be quoted as Ansible will ultimately try to interpret it
+# as a Python literal.  Extra spaces in the string should be
+# preserved, but Ansible strips leading and trailing spaces.
+simple_dict = {"k1": "v1",    'k2': 'v2'}  # dict string

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,6 @@
-import logging
 import sys
 import unittest
+import imp
 import os
 
 sys.path.insert(0, os.path.realpath('../lib'))
@@ -145,7 +145,6 @@ class FactCacheTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
     unittest.main(exit=True)
 
     try:

--- a/test/test.py
+++ b/test/test.py
@@ -1,6 +1,6 @@
+import logging
 import sys
 import unittest
-import imp
 import os
 
 sys.path.insert(0, os.path.realpath('../lib'))
@@ -69,6 +69,18 @@ class HostParseTestCase(unittest.TestCase):
         self.assertIn('web02.dev.local', ansible.hosts)
         self.assertIn('fe03.dev02.local', ansible.hosts)
 
+    def testIniKeyValueParse(self):
+        """
+        Verify that key=value is parsed correctly in inventory ini files.
+        """
+        fact_dirs = ['f_hostparse/out']
+        inventories = ['f_hostparse/hosts_ini_key_value']
+        ansible = ansiblecmdb.Ansible(fact_dirs, inventories)
+        host_vars = ansible.hosts['db.dev.local']['hostvars']
+        self.assertEqual(host_vars['simple_list'], '["item1", "item2"]')
+        self.assertEqual(host_vars['simple_dict'],
+                         '''{"k1": "v1",    'k2': 'v2'}''')
+
 
 class InventoryTestCase(unittest.TestCase):
     def testHostsDir(self):
@@ -133,6 +145,7 @@ class FactCacheTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
     unittest.main(exit=True)
 
     try:


### PR DESCRIPTION
The parsing of group variables from inventory ini files doesn't do what Ansible documents or does. Ansible might not have documented this when the ansible-cmdb code was written, but the User Guide https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-formats-hosts-and-groups says

> Values passed in the INI format using the key=value syntax are interpreted differently depending on where they are declared:
> 
> When declared inline with the host, INI values are interpreted as Python literal structures (strings, numbers, tuples, lists, dicts, booleans, None). Host lines accept multiple key=value parameters per line. Therefore they need a way to indicate that a space is part of a value rather than a separator.
>
> When declared in a :vars section, INI values are interpreted as strings. For example var=FALSE  would create a string equal to ‘FALSE’. Unlike host lines, :vars sections accept only a single entry per line, so everything after the = must be the value for the entry.

So parsing a :vars section line doesn't need to try yaml or shlex tokenizing. Simply strip a trailing comment from the line if present, split on = and return the left and right parts as strings. The unspecified bit is what happens to leading and trailing whitespace on the left and right sides. Common practice in ini files is to strip whitespace, so that's what I did.