### PR TITLE
Allow 'ansible-cmdb' wrapper to be a symlink

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -30,7 +30,7 @@ find_py_bin () {
 
 # Find path to the real ansible-cmdb python script
 find_cmdb_bin () {
-    BIN_DIR=$(dirname "$0")
+    BIN_DIR=$(dirname "$(readlink -f "$0")")
     if [ -f "$BIN_DIR/ansible-cmdb.py" ]; then
         dbg "Trying ansible-cmdb bin: $BIN_DIR/ansible-cmdb.py"
         echo "$BIN_DIR/ansible-cmdb.py"


### PR DESCRIPTION
Enhances 'ansible-cmdb' wrapper script to be able to find 'ansible-cmdb.py' when 'ansible-cmdb' is a symlink.

Currently the search paths around 'ansible-cmdb' are relative to the location of the symlink. We can use 'readlink -f'
to instead follow the symlink and search from the actual location of 'ansible-cmdb'

The use-case where this comes up is we want to add 'ansible-cmdb' to the path. To do this we are creating a symlink
from '/bin/ansible-cmdb' to its actual location. After this update,  the command '/bin/ansible-cmdb' works as expected
because the wrapper script follows the symlink.

-------------------

This update is backward compatible. If '$0' is a file, then "readlink -f" will return the canonical file name of that file (existing behavior), otherwise if '$0' is a symlink then we recursively follow every symlink of '$0'.

For convenience,  the man info on the '-f' flag:

```
     -f, --canonicalize
              canonicalize by following every symlink in every component of the given name recursively;
              all but the last component must exist
```

And the man info of 'readlink':

``` 
NAME
       readlink - print resolved symbolic links or canonical file names
```
