### PR TITLE
Fix python binary lookup on debian bullseye (11)

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -11,7 +11,7 @@ dbg () {
 
 # Find suitable python binary
 find_py_bin () {
-    which -a python | while read -r TRY_PY_BIN
+    which -a python3 python2 python | while read -r TRY_PY_BIN
     do
         dbg "Trying python bin: $TRY_PY_BIN"
 


### PR DESCRIPTION
On debian bullseye (now stable), the `/usr/bin/python` symlink is [intentionally removed](https://wiki.debian.org/Python#Python_in_Debian) (see the note). With this change, the wrapper detects `python3`, `python2` and `python` symlinks in this order.

The error that lead me to this was (added so that searches on github will find this PR):
`No suitable python version found (v2.7 or higher required). Aborting`