### PR TITLE
Fix typo in header test for html report

### DIFF
--- a/src/ansiblecmdb/data/tpl/html_fancy.tpl
+++ b/src/ansiblecmdb/data/tpl/html_fancy.tpl
@@ -30,7 +30,7 @@ if host_details is False:
 %>
 
 <% html_header("Ansible Overview", local_js, res_url) %>
-<% html_header_bar("Host overview") %>
+<% html_header_bar("Host Overview") %>
 <% html_col_toggles(cols) %>
 <% html_host_overview(cols, hosts, skip_empty=skip_empty, link_type=link_type) %>
 % if host_details is True:

--- a/src/ansiblecmdb/data/tpl/html_fancy_split_overview.tpl
+++ b/src/ansiblecmdb/data/tpl/html_fancy_split_overview.tpl
@@ -30,7 +30,7 @@ if host_details is False:
 %>
 
 <% html_header("Ansible Overview", local_js, res_url) %>
-<% html_header_bar("Host overview") %>
+<% html_header_bar("Host Overview") %>
 <% html_col_toggles(cols) %>
 <% html_host_overview(cols, hosts, skip_empty=skip_empty, link_type=link_type) %>
 <script>


### PR DESCRIPTION
By default, the html report header is set to "Host overview", but to scroll js function will reset it to "Host Overview", see:

https://github.com/fboender/ansible-cmdb/blob/8e7f8d2a422f80cb2c43b1eaea2f2d9450834c10/src/ansiblecmdb/data/tpl/html_fancy.tpl#L62) 

which gives a weird behavior each time. 
This fixes the typo in default values of the header.