### PR TITLE
Addition of New YAML Template

### DIFF
--- a/src/ansiblecmdb/data/tpl/yaml.tpl
+++ b/src/ansiblecmdb/data/tpl/yaml.tpl
@@ -1,0 +1,11 @@
+<%
+import yaml
+
+class CustDumper(yaml.SafeDumper):
+    def represent_data(self, data):
+        if isinstance(data, set):
+            return self.represent_list(data)
+        return super().represent_data(data)
+
+print(yaml.dump(hosts, Dumper=CustDumper))
+%>


### PR DESCRIPTION
I have created a YAML Template for Ansible-CMDB that helps with displaying the retrieved Ansible-Facts in the human-readable format of YAML. 

In order to use this template, users can run `ansible-cmdb -t yaml out/`, where `yaml` is the name of this template and `out/` is the directory where Ansible-Facts are being stored. 

An excerpt of the output that is displayed after running this command is as follows:
```
192.168.xxx.xxx:
  ansible_facts:
    ansible_all_ipv4_addresses:
    - 192.168.xxx.xxx
    - 172.xxx.xxx.xxx
    - 192.xxx.xxx.xxx
    ansible_all_ipv6_addresses:
    - fe80::9ab7:9338:xxxx:xxxx
    ansible_apparmor:
      status: enabled
    ansible_architecture: x86_64
    ansible_bios_date: 04/01/
[output.txt](https://github.com/fboender/ansible-cmdb/files/14228415/output.txt)
2014
    ansible_bios_vendor: SeaBIOS
    ansible_bios_version: 1.16.0-debian-1.16.0-5
    ansible_board_asset_tag: NA
```

The resources used as references for creating this template were as follows:
- [Ansible-CMDB `json.tpl` Template](https://github.com/fboender/ansible-cmdb/blob/master/src/ansiblecmdb/data/tpl/json.tpl)
- [StackOverflow post on "How to keep yaml Format when using yaml.SafeDumper"](https://stackoverflow.com/questions/75545082/how-to-keep-yaml-format-when-using-yaml-safedumper)
- [PythonLand Guide for "Writing Or Dumping YAML To A File](https://python.land/data-processing/python-yaml#Writing_or_dumping_YAML_to_a_file)

Please feel free to provide any suggestions or feedback on how this template can be further improved.