### PR TITLE
Add Python 3 as a candidate in find_py_bin to ensure compatibility with modern Python versions

### DIFF
--- a/src/ansible-cmdb
+++ b/src/ansible-cmdb
@@ -11,7 +11,7 @@ dbg () {
 
 # Find suitable python binary
 find_py_bin () {
-    which -a python | while read -r TRY_PY_BIN
+    which -a python3 python | while read -r TRY_PY_BIN
     do
         dbg "Trying python bin: $TRY_PY_BIN"
 


### PR DESCRIPTION
Summary
This pull request modifies the find_py_bin function to include python3 as a candidate when searching for a suitable Python interpreter. This change ensures compatibility with systems where Python 3 is the primary or only available version.

Problem
In the original find_py_bin function, only python was considered when searching for an available interpreter. However, many modern systems (including recent versions of Ubuntu) use python3 as the default Python interpreter, and python may not be available. As a result, the following error is raised, even when a suitable Python 3 installation exists:

`No suitable python version found (v2.7 or higher required). Aborting`

Solution
This modification updates the find_py_bin function to search for both python3 and python interpreters using which -a python3 python. This ensures that python3 is considered as a valid candidate if present, allowing the script to run smoothly on systems with only Python 3 installed.